### PR TITLE
update sources to Bosque v0.5.0-rc-1

### DIFF
--- a/src/Sample/Apps/BooksAndRecords/App.bsq
+++ b/src/Sample/Apps/BooksAndRecords/App.bsq
@@ -11,8 +11,8 @@ typedef Quantity = Int;
 typedef Value = Int;
 
 entity Deal { 
-    invariant this.price >= 0; //TODO in Bosque add diagnostics msg option
-    invariant this.quantity >= 0;
+    invariant $price >= 0; //TODO in Bosque add diagnostics msg option
+    invariant $quantity >= 0;
 
     field id: ID;
     field product: ProductID;
@@ -26,8 +26,8 @@ concept Event {
 }
 
 entity DealOpened provides Event {
-    invariant this.price >= 0; //TODO in Bosque add diagnostics msg option
-    invariant this.quantity >= 0;
+    invariant $price >= 0; //TODO in Bosque add diagnostics msg option
+    invariant $quantity >= 0;
 
     field dealId: ID;
     field productId: ProductID;
@@ -40,19 +40,20 @@ entity DealClosed provides Event {
 }
 
 function dealValue(d: Deal): Value {
-    return Math::mult(d.price, d.quantity);
+    return d.price * d.quantity;
 }
 
 function openDeal(state: DealState, deal: DealOpened): DealState {
-    check !state->has(deal.dealId);
+    check !state.has(deal.dealId);
        
-    return state->insert(deal.dealId, Deal{id=deal.dealId, product=deal.productId, price=deal.price, quantity=deal.quantity});
+    return state.unionWith(DealState@{deal.dealId=>Deal@{id=deal.dealId, product=deal.productId, price=deal.price, quantity=deal.quantity}});
 }
 
 function closeDeal(state: DealState, deal: DealClosed): DealState {
-    check state->has(deal.dealId);
-       
-    return state->remove(deal.dealId);
+    check state.has(deal.dealId);
+
+    let toExclude = Set<ID>@{deal.dealId};
+    return state.excludeSet(toExclude);
 }
 
 function processDealEvent(state: DealState, event: Event): DealState {
@@ -64,10 +65,10 @@ function processDealEvent(state: DealState, event: Event): DealState {
 
 //A mock deal state manager for testing and examples
 function loadDealState(): DealState {
-    var! state = DealState{};
+    var state = DealState@{};
 
-    state = processDealEvent(state, DealOpened{dealId = 1, productId = "tea", price = 10, quantity = 100});
-    state = processDealEvent(state, DealOpened{dealId = 2, productId = "coffee", price = 1, quantity = 100});
+    state = processDealEvent(state, DealOpened@{dealId = 1, productId = "tea", price = 10, quantity = 100});
+    state = processDealEvent(state, DealOpened@{dealId = 2, productId = "coffee", price = 1, quantity = 100});
 
     return state;
 }
@@ -82,21 +83,21 @@ entrypoint function openDealAPI(dealid: ID, product: ProductID, price: Int, quan
     requires quantity >= 0; //<----- oops forgot to validate input
 {
     var state = loadDealState();
-    if(state->has(dealid)) {
+    if(state.has(dealid)) {
         return false;
     }
 
-    var nstate = processDealEvent(state, DealOpened{dealId = dealid, productId = product, price = price, quantity = quantity});
+    var nstate = processDealEvent(state, DealOpened@{dealId = dealid, productId = product, price = price, quantity = quantity});
     return storeDealState(nstate);
 }
 
 entrypoint function closeDealAPI(dealid: ID): Bool 
 {
     var state = loadDealState();
-    if(!state->has(dealid)) {
+    if(!state.has(dealid)) {
         return false;
     }
 
-    var nstate = processDealEvent(state, DealClosed{dealId = dealid});
+    var nstate = processDealEvent(state, DealClosed@{dealId = dealid});
     return storeDealState(nstate);
 }

--- a/src/Sample/Apps/Order/App.bsq
+++ b/src/Sample/Apps/Order/App.bsq
@@ -19,7 +19,7 @@ entity Market provides OrderPrice {
 }
 
 entity Limit provides OrderPrice {
-    invariant this.price >= 0;
+    invariant $price >= 0;
 
     field price: Price;
 }
@@ -30,7 +30,7 @@ concept Request {
 }
 
 entity BuyRequest provides Request {
-    invariant this.quantity >= 0;
+    invariant $quantity >= 0;
 
     field quantity: Quantity;
     field product: ProductID;
@@ -56,7 +56,7 @@ entity DisagreeablePrice provides RejectReason {
 //An order can be:
 //  * Accepted if everything goes well, or
 //  * Invalid if a validation rule was violated -- we treat this as a terminal failure that is checked to never happen, or
-//  * Rejected if the order was valid but we didn't accpt it for business reasons.
+//  * Rejected if the order was valid but we didn't accept it for business reasons.
 concept Response {
 }
 
@@ -65,8 +65,8 @@ concept BuyResponse provides Response {
 }
 
 entity BuyAccepted provides BuyResponse {
-    invariant this.price >= 0;
-    invariant this.quantity >= 0;
+    invariant $price >= 0;
+    invariant $quantity >= 0;
 
     field productId: ProductID;
     field price: Price;
@@ -74,31 +74,33 @@ entity BuyAccepted provides BuyResponse {
 }
 
 entity BuyRejected provides BuyResponse {
-    invariant !this.reasons->empty();
+    invariant !$reasons.empty();
 
     field reasons: List<RejectReason>;
 }
 
 entity SellAccepted provides Response {
-    invariant this.price >= 0;
+    invariant $price >= 0;
 
     field id: ID;
     field price: Price;
 }
 
 function lockinPrice(requestPrice: OrderPrice, marketPrice: Price): Price {
-    return requestPrice->is<Limit>() ? requestPrice.price : marketPrice;
+    return requestPrice.is<Limit>() ? requestPrice.price : marketPrice;
 }
 
 function acceptability(request: BuyRequest, marketPrice: Price, availableInventory: Quantity): List<RejectReason> {
-    var! rejects = List<RejectReason>{};
+    var rejects = List<RejectReason>@{};
 
     if(availableInventory < request.quantity) {
-        rejects = rejects->push(InsufficientInventory{actualQuantity=availableInventory, requestedQuantity=request.quantity});
+        let reasons = List<RejectReason>@{InsufficientInventory@{actualQuantity=availableInventory, requestedQuantity=request.quantity}};
+        rejects = rejects.append(reasons);
     }
 
-    if(lockinPrice(request.requestPrice, marketPrice) < Math::div(Math::mult(marketPrice, 9), 10)) {
-        rejects = rejects->push(DisagreeablePrice{actualPrice=marketPrice, requestedPrice=request.requestPrice});
+    if(lockinPrice(request.requestPrice, marketPrice) < ((marketPrice * 9) / 10)) {
+        let reasons = List<RejectReason>@{DisagreeablePrice@{actualPrice=marketPrice, requestedPrice=request.requestPrice}};
+        rejects = rejects.append(reasons);
     }
     
     return rejects;
@@ -109,36 +111,39 @@ function processBuy(request: BuyRequest, marketPrice: Price, availableInventory:
     var rejections = acceptability(request, marketPrice, availableInventory);
     var lockPrice = lockinPrice(request.requestPrice, marketPrice);
     
-    if(!rejections->empty()) {
-        return BuyRejected{id=request.id, reasons=rejections};
+    if(!rejections.empty()) {
+        return BuyRejected@{id=request.id, reasons=rejections};
     }
     else {
-        return BuyAccepted{id=request.id, productId=request.product, price=lockPrice, quantity=request.quantity};
+        return BuyAccepted@{id=request.id, productId=request.product, price=lockPrice, quantity=request.quantity};
     }
 }
 
 function processSell(request: SellRequest, marketPrice: Price): SellAccepted {
     var lockPrice = lockinPrice(request.requestPrice, marketPrice);
-    return SellAccepted{id=request.id, price=lockPrice};
+    return SellAccepted@{id=request.id, price=lockPrice};
 }
 
 function availability(startOfDayPosition: Quantity, buys: List<BuyResponse>): Quantity {
-    var sumOfBuys = buys->ofType<BuyAccepted>()->map<Quantity>(fn(response) => response.quantity)->sum();
+    var sumOfBuys = buys.ofType<BuyAccepted>().map<Quantity>(fn(response) => response.quantity).sum();
     return startOfDayPosition - sumOfBuys;
 }
 
 ///////////////////////////////////////////////
 
+typedef BuyResponses = Map<ID, BuyResponse>;
+typedef Sells = Map<ID, SellAccepted>;
+
 entity OrderState { 
-    field buys: Map<ID, BuyResponse>;
-    field sells: Map<ID, SellAccepted>;
+    field buys: BuyResponses;
+    field sells: Sells;
 }
 
 //A mock state manager for testing and examples
 function loadState(): { state: OrderState, prices: MarketPrices, quantities: ProductQuantities } {
-    var! state = OrderState{ buys=Map<ID, BuyResponse>{}, sells=Map<ID, SellAccepted>{} };
-    var priceState = Map<ProductID, Price>{ ["coffee", 25], ["tea", 35] };
-    var quantityState = Map<ProductID, Price>{ ["coffee", 3], ["tea", 10] };
+    var state = OrderState@{ buys=BuyResponses@{}, sells=Sells@{} };
+    var priceState = Map<ProductID, Price>@{ "coffee" => 25, "tea" => 35 };
+    var quantityState = Map<ProductID, Price>@{ "coffee" => 3, "tea" => 10 };
 
     return { state=state, prices=priceState, quantities=quantityState };
 }
@@ -152,17 +157,17 @@ entrypoint function apiBuyMarket(id: ID, quantity: Quantity, product: ProductID)
     requires quantity >= 0;
 {
     var { state=state, prices=prices, quantities=quantities } = loadState();
-    if (state.buys->has(id) || state.sells->has(id)) {
+    if (state.buys.has(id) || state.sells.has(id)) {
         return false;
     }
 
-    var request = BuyRequest{id=id, requestPrice=Market{}, quantity=quantity, product=product};
-    var currentMarketPrice = prices->tryGet(request.product);
-    var currentAvailility = availability(quantities->tryGet(request.product) ?| 0, state.buys->getValues());
-    var buyresult = currentMarketPrice ?& processBuy(request, currentMarketPrice, currentAvailility);
-    var nstate = buyresult?->is<BuyAccepted>() ? OrderState{buys=state.buys->add(buyresult.id, buyresult), sells=state.sells} : state;
+    var request = BuyRequest@{id=id, requestPrice=Market@{}, quantity=quantity, product=product};
+    var currentMarketPrice = prices.tryGet(request.product);
+    var currentAvailability = availability(quantities.tryGet(request.product) ?| 0, state.buys.values());
+    var buyresult = currentMarketPrice ?& processBuy(request, currentMarketPrice, currentAvailability);
+    var nstate = buyresult?.is<BuyAccepted>() ? OrderState@{buys=state.buys.unionWith(BuyResponses@{(buyresult.id=>buyresult).convert<ID, BuyResponse>()}), sells=state.sells} : state;
 
-    return storeState(nstate) && buyresult?->is<BuyAccepted>();
+    return storeState(nstate) && buyresult?.is<BuyAccepted>();
 }
 
 entrypoint function apiBuyLimit(id: ID, requestPrice: Price, quantity: Quantity, product: ProductID): Bool
@@ -170,15 +175,15 @@ entrypoint function apiBuyLimit(id: ID, requestPrice: Price, quantity: Quantity,
     requires quantity >= 0;
 {
     var { state=state, prices=prices, quantities=quantities } = loadState();
-    if (state.buys->has(id) || state.sells->has(id)) {
+    if (state.buys.has(id) || state.sells.has(id)) {
         return false;
     }
 
-    var request = BuyRequest{id=id, requestPrice=Limit{price=requestPrice}, quantity=quantity, product=product};
-    var currentMarketPrice = prices->tryGet(request.product);
-    var currentAvailility = availability(quantities->tryGet(request.product) ?| 0, state.buys->getValues());
-    var buyresult = currentMarketPrice ?& processBuy(request, currentMarketPrice, currentAvailility);
-    var nstate = buyresult?->is<BuyAccepted>() ? OrderState{buys=state.buys->add(buyresult.id, buyresult), sells=state.sells} : state;
+    var request = BuyRequest@{id=id, requestPrice=Limit@{price=requestPrice}, quantity=quantity, product=product};
+    var currentMarketPrice = prices.tryGet(request.product);
+    var currentAvailability = availability(quantities.tryGet(request.product) ?| 0, state.buys.values());
+    var buyresult = currentMarketPrice ?& processBuy(request, currentMarketPrice, currentAvailability);
+    var nstate = buyresult?.is<BuyAccepted>() ? OrderState@{buys=state.buys.unionWith(BuyResponses@{(buyresult.id=>buyresult).convert<ID, BuyResponse>()}), sells=state.sells} : state;
 
-    return storeState(nstate) && buyresult?->is<BuyAccepted>();
+    return storeState(nstate) && buyresult?.is<BuyAccepted>();
 }


### PR DESCRIPTION
Hi,

This PR updates the sources in **BooksAndRecords** and **Orders** to latest Bosque **v0.5.0-rc-1**.

I've kept most of the original code unchanged. A big chunk of fixes deals with syntax errors, but there are also a few changes that are related to Bosque's language design. 

For example, the method Map<K,V>.**add** is not available anymore ([and for good reasons](https://github.com/microsoft/BosqueLanguage/issues/342#issuecomment-645649181)), so that I replaced it with **unionWith**.  I also had to introduce some extra Map-type conversions, because of some [important reasons](https://github.com/microsoft/BosqueLanguage/issues/346#issuecomment-646843899).

All in all, the errors are gone except one that has to do with the **if-else statemens**. But soon [there will be a fix for that](https://github.com/microsoft/BosqueLanguage/issues/286#issuecomment-646424887).


Of course, _feel free to ignore this PR_.

I was using this repo for education purposes only, because there aren't that many Bosque resources available. 

Regards, 

